### PR TITLE
Add phone call to store & scroll order screen

### DIFF
--- a/lib/order_page.dart
+++ b/lib/order_page.dart
@@ -12,9 +12,11 @@ class OrderPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('注文ページ'),
       ),
-      body: const Padding(
-        padding: EdgeInsets.all(16.0),
-        child: OrderForm(),
+      body: const SingleChildScrollView(
+        child: Padding(
+          padding: EdgeInsets.all(16.0),
+          child: OrderForm(),
+        ),
       ),
     );
   }

--- a/lib/store_page.dart
+++ b/lib/store_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'order.dart';
 import 'store.dart';
 
@@ -96,6 +97,7 @@ class StorePage extends StatelessWidget {
                 leading: const Icon(Icons.call),
                 title: const Text('電話'),
                 subtitle: Text(store.phoneNumber),
+                onTap: () => _makePhoneCall(store.phoneNumber),
               ),
               ListTile(
                 leading: const Icon(Icons.schedule),
@@ -122,5 +124,14 @@ class StorePage extends StatelessWidget {
         );
       },
     );
+  }
+
+  Future<void> _makePhoneCall(String phoneNumber) async {
+    final Uri phoneUri = Uri(scheme: 'tel', path: phoneNumber);
+    if (await canLaunchUrl(phoneUri)) {
+      await launchUrl(phoneUri);
+    } else {
+      throw 'Could not launch $phoneUri';
+    }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   latlong2: ^0.9.1
   provider: ^6.1.2
   go_router: ^14.2.7
+  url_launcher: ^6.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
以下2点の修正追加
1. store タブにおける店舗詳細画面から，電話の項目をタップするとその電話番号を入力した状態で電話アプリを起動するコードを追加．
2. オーダ画面にスクロール機能を実装．