### PR TITLE
Update transition from product selection to purchase in a one-way direction

### DIFF
--- a/lib/pages/cart_page.dart
+++ b/lib/pages/cart_page.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+import '../resources/order.dart';
+
+class CartPage extends StatelessWidget {
+  const CartPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('選択商品ページ'),
+      ),
+      body: const CartForm(),
+    );
+  }
+}
+
+class CartForm extends StatefulWidget {
+  const CartForm({super.key});
+
+  @override
+  // ignore: no_logic_in_create_state
+  CartFormState createState() => CartFormState();
+}
+
+class CartFormState extends State<CartForm> {
+  CartFormState();
+
+  @override
+  Widget build(BuildContext context) {
+    final orderData = Provider.of<Order>(context);
+    List<OrderedProduct> products = orderData.productsInfo.products;
+    const isSelectable = true;
+
+    return Column(
+      children: [
+        Expanded(
+          child: ListView.builder(
+              itemCount: products.length, // 商品の数
+              itemBuilder: (context, index) {
+                final product = products[index].product;
+                return Card(
+                    margin: const EdgeInsets.symmetric(
+                        vertical: 8.0,
+                        horizontal: 16.0
+                    ),
+                    child: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            // アイコン
+                            const Icon(
+                              Icons.shopping_cart,
+                              size: 50.0,
+                            ),
+                            const SizedBox(width: 16.0),
+                            // 商品名、説明、値段を含むColumn
+                            Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    // 商品名
+                                    Text(
+                                      product.name,
+                                      style: const TextStyle(
+                                        fontSize: 18,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                    const SizedBox(height: 8.0),
+                                    // 商品説明
+                                    Text(
+                                      product.description,
+                                      style: const TextStyle(
+                                        fontSize: 14,
+                                        color: Colors.grey,
+                                      ),
+                                    ),
+                                    const SizedBox(height: 8.0),
+                                    // 値段
+                                    Text(
+                                      '¥${product.price}',
+                                      style: const TextStyle(
+                                        fontSize: 16,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                  ],
+                                )
+                            ),
+                            const SizedBox(height: 16.0),
+                            // 数量の増減ボタンと表示
+                            Visibility(
+                                visible: isSelectable,
+                                child: Column(
+                                  children: [
+                                    Row(
+                                      mainAxisAlignment: MainAxisAlignment.end,
+                                      children: [
+                                        // マイナスボタン
+                                        IconButton(
+                                          icon: const Icon(Icons.remove),
+                                          onPressed: () {
+                                            setState(() {
+                                              final currentQuantity = orderData.getOrderedProductQuantity(product);
+                                              if (currentQuantity > 0) {
+                                                orderData.changeOrderedProduct(product, currentQuantity - 1);
+                                              }
+                                            });
+                                          },
+                                        ),
+                                        // 現在の数量を表示
+                                        Text(
+                                          '${orderData.getOrderedProductQuantity(product)}',
+                                          style: const TextStyle(fontSize: 16),
+                                        ),
+                                        // プラスボタン
+                                        IconButton(
+                                          icon: const Icon(Icons.add),
+                                          onPressed: () {
+                                            setState(() {
+                                              final currentQuantity = orderData.getOrderedProductQuantity(product);
+                                              orderData.changeOrderedProduct(product, currentQuantity + 1);
+                                            }
+                                            );
+                                          },
+                                        ),
+                                      ],
+                                    ),
+                                    const SizedBox(height: 8.0),
+                                    IconButton(
+                                      icon: const Icon(Icons.delete),
+                                      onPressed: () {
+                                        setState(() {
+                                          orderData.changeOrderedProduct(product, 0);
+                                        }
+                                        );
+                                      },
+                                    ),
+                                  ],
+                                )
+                            ),
+                          ],
+                        )
+                    )
+                );
+              }
+          )
+        ),
+
+        // 確定ボタン部分
+        Container(
+          padding: const EdgeInsets.all(16.0),
+          child: SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+                onPressed: () {
+                  // ボタン押下時の処理
+                  GoRouter.of(context).push('/order');
+                },
+                child: const Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    SizedBox(width: 8.0),
+                    Icon(
+                      Icons.shopping_cart,
+                      size: 40.0,
+                    ),
+                    Text('レジに進む'),
+                  ],
+                )
+            ),
+          ),
+        ),
+        // ListView
+      ],
+    );
+  }
+}

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,61 +1,59 @@
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
-
-
-class HomeItem{
-  final String text;
-  final String imagePath;
-  final String pagePath;
-
-  HomeItem(this.text, this.imagePath, this.pagePath);
-}
-
-List<HomeItem> homeitems =
-  [HomeItem("Order", "IMG_8832.jpg", "order"),
-   HomeItem("Product", "IMG_8833.jpg", "product"),
-   HomeItem("Store", "IMG_8834.jpg", "store")
-  ];
+import 'package:latin_one/pages/product_page.dart';
+import 'package:provider/provider.dart';
+import '../resources/order.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return ListView.separated(
-      itemBuilder: (BuildContext context, int index){
-        return _menuItem(context, homeitems[index]);
-      },
-      separatorBuilder: (BuildContext context, int index){
-        return separatorItem();
-      },
-      itemCount: homeitems.length,
-    );
-  }
+    final orderData = Provider.of<Order>(context);
 
-  Widget _menuItem(BuildContext context, HomeItem homeitem){
-    return GestureDetector(
-      child:Container(
-        height: 300,
-        width: 500,
-        decoration: BoxDecoration(
-          image: DecorationImage(image: AssetImage("images/${homeitem.imagePath}")),
+    return Column(
+      children: [
+        // 広告バナー
+        Container(
+          height: 100,
+          color: Colors.blueAccent,
+          child: const Center(
+            child: Text(
+              '広告バナーなどという姑息な収益手段\nなんぞ取りおってからに  \\\(゜□゜\\\)',
+              style: TextStyle(color: Colors.white, fontSize: 18),
+            ),
+          ),
         ),
-        child: Center(
-            child: Text(homeitem.text,
-                style: const TextStyle(fontSize: 50)
-            )
-        )
-      ),
-      onTap: (){
-        GoRouter.of(context).go('/${homeitem.pagePath}',extra: false);
-      },
-    );
-  }
-
-  Widget separatorItem() {
-    return Container(
-      height: 10,
-      color: Colors.white,
+        // ListView
+        Expanded(
+          child: const ProductPage(isSelectable: true),
+        ),
+        // 確定ボタン部分
+        Container(
+          padding: const EdgeInsets.all(16.0),
+          child: SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed: () {
+                // ボタン押下時の処理
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('確定ボタンが押されました')),
+                );
+              },
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const SizedBox(width: 8.0),
+                  const Icon(
+                    Icons.shopping_cart,
+                    size: 40.0,
+                  ),
+                  Text('${orderData.productsInfo.products.length} 個:  ￥${orderData.productsInfo.amount}'),
+                ],
+              )
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -19,7 +19,7 @@ class HomePage extends StatelessWidget {
           color: Colors.blueAccent,
           child: const Center(
             child: Text(
-              '広告バナーなどという姑息な収益手段\nなんぞ取りおってからに  \\(゜□゜\\)',
+              '広告バナー',
               style: TextStyle(color: Colors.white, fontSize: 18),
             ),
           ),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:latin_one/pages/product_page.dart';
 import 'package:provider/provider.dart';
 import '../resources/order.dart';
@@ -18,14 +19,14 @@ class HomePage extends StatelessWidget {
           color: Colors.blueAccent,
           child: const Center(
             child: Text(
-              '広告バナーなどという姑息な収益手段\nなんぞ取りおってからに  \\\(゜□゜\\\)',
+              '広告バナーなどという姑息な収益手段\nなんぞ取りおってからに  \\(゜□゜\\)',
               style: TextStyle(color: Colors.white, fontSize: 18),
             ),
           ),
         ),
         // ListView
-        Expanded(
-          child: const ProductPage(isSelectable: true),
+        const Expanded(
+          child: ProductPage(),
         ),
         // 確定ボタン部分
         Container(
@@ -35,9 +36,7 @@ class HomePage extends StatelessWidget {
             child: ElevatedButton(
               onPressed: () {
                 // ボタン押下時の処理
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('確定ボタンが押されました')),
-                );
+                GoRouter.of(context).push('/cart');
               },
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/pages/layout.dart
+++ b/lib/pages/layout.dart
@@ -34,14 +34,14 @@ class AppLayout extends StatelessWidget {
               GoRouter.of(context).go('/');
             }
           ),
-          const IconButton(
-            icon: Icon(Icons.email, color: Colors.white),
-            onPressed: null, //TODO:実装
-          ),
-          const IconButton(
-            icon: Icon(Icons.settings, color: Colors.white),
-            onPressed: null, //TODO:実装
-          ),
+          // const IconButton(
+          //   icon: Icon(Icons.email, color: Colors.white),
+          //   onPressed: null, //TODO:実装
+          // ),
+          // const IconButton(
+          //   icon: Icon(Icons.settings, color: Colors.white),
+          //   onPressed: null, //TODO:実装
+          // ),
         ],
       ),
 

--- a/lib/pages/layout.dart
+++ b/lib/pages/layout.dart
@@ -27,12 +27,18 @@ class AppLayout extends StatelessWidget {
               GoRouter.of(context).push('/account');
           },
         ),
-        actions: const <Widget>[
+        actions: <Widget>[
           IconButton(
+            icon: const Icon(Icons.home, color: Colors.white),
+            onPressed: (){
+              GoRouter.of(context).go('/');
+            }
+          ),
+          const IconButton(
             icon: Icon(Icons.email, color: Colors.white),
             onPressed: null, //TODO:実装
           ),
-          IconButton(
+          const IconButton(
             icon: Icon(Icons.settings, color: Colors.white),
             onPressed: null, //TODO:実装
           ),

--- a/lib/pages/layout.dart
+++ b/lib/pages/layout.dart
@@ -40,33 +40,7 @@ class AppLayout extends StatelessWidget {
       ),
 
       //Body
-      body: navigationShell,
-
-      // BottomNavigationBar
-      bottomNavigationBar: BottomNavigationBar(
-        type: BottomNavigationBarType.fixed,
-        onTap: (int index) => navigationShell.goBranch(index),
-        currentIndex: navigationShell.currentIndex,
-        fixedColor: Colors.blueAccent,
-        items: const <BottomNavigationBarItem>[
-          BottomNavigationBarItem(
-            icon: Icon(Icons.home),
-            label: 'Home',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.store),
-            label: 'Store',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.local_shipping),
-            label: 'Order',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.shopping_cart),
-            label: 'Product',
-          ),
-        ],
-      ),
+      body: navigationShell
     );
   }
 }

--- a/lib/pages/order_page.dart
+++ b/lib/pages/order_page.dart
@@ -40,20 +40,16 @@ class OrderFormState extends State<OrderForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        // 商品表示
+        DisplayCurrentProducts(productsInfo: orderData.productsInfo),
+        const SizedBox(height: 24.0),
+
         // 店舗選択ボタン
         StoreSelectButton(orderData.store),
         const SizedBox(height: 16.0),
 
         // 店舗表示
         DisplayCurrentStore(store: orderData.store),
-        const SizedBox(height: 16.0),
-
-        // 商品選択ボタン
-        ProductSelectButton(orderData.productsInfo.products),
-        const SizedBox(height: 16.0),
-
-        // 商品表示
-        DisplayCurrentProducts(productsInfo: orderData.productsInfo),
         const SizedBox(height: 16.0),
 
         // 支払い方法選択
@@ -167,44 +163,6 @@ class DisplayCurrentStore extends StatelessWidget {
           ]
       );
     }
-  }
-}
-
-class ProductSelectButton extends StatelessWidget {
-  final List<OrderedProduct> products;
-
-  const ProductSelectButton(this.products, {super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    String text;
-    if (products.isEmpty) {
-      text = '商品を選択';
-    } else {
-      text = '商品を選択済み';
-    }
-
-    return SizedBox(
-      width: double.infinity, // ボタンを横幅いっぱいに広げる
-      child: ElevatedButton(
-        style: ElevatedButton.styleFrom(
-          shape: const RoundedRectangleBorder(
-            borderRadius: BorderRadius.zero, // 四角にするために角丸を0に設定
-          ),
-        ),
-        onPressed: () {
-          GoRouter.of(context).push('/product',extra: true);
-        },
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Text(text),
-            const SizedBox(width: 8.0),
-            const Icon(Icons.arrow_circle_right),
-          ],
-        ),
-      ),
-    );
   }
 }
 

--- a/lib/pages/product_page.dart
+++ b/lib/pages/product_page.dart
@@ -6,8 +6,7 @@ import '../db/firebase/connector.dart';
 import '../resources/order.dart' as order;
 
 class ProductPage extends StatelessWidget {
-  final bool isSelectable;
-  const ProductPage({super.key, required this.isSelectable});
+  const ProductPage({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -15,25 +14,23 @@ class ProductPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('商品ページ'),
       ),
-      body: ProductForm(isSelectable),
+      body: const ProductForm(),
     );
   }
 }
 
 class ProductForm extends StatefulWidget {
-  final bool isSelectable;
-  const ProductForm(this.isSelectable, {super.key});
+  const ProductForm({super.key});
 
   @override
   // ignore: no_logic_in_create_state
-  ProductFormState createState() => ProductFormState(isSelectable);
+  ProductFormState createState() => ProductFormState();
 }
 
 class ProductFormState extends State<ProductForm> {
   late Future<List<Product>> future;
 
-  bool isSelectable;
-  ProductFormState(this.isSelectable);
+  ProductFormState();
 
   @override
   initState() {
@@ -115,7 +112,6 @@ class ProductFormState extends State<ProductForm> {
                     const SizedBox(height: 16.0),
                     // 数量の増減ボタンと表示
                     Visibility(
-                      visible: isSelectable,
                       child: Row(
                       mainAxisAlignment: MainAxisAlignment.end,
                       children: [

--- a/lib/pages/store_page.dart
+++ b/lib/pages/store_page.dart
@@ -10,49 +10,55 @@ import '../db/firebase/connector.dart';
 
 class StorePage extends StatelessWidget {
   StorePage({super.key});
-  Future<List<Store>> future = fetchStore(FirebaseFirestore.instance);
+  final Future<List<Store>> future = fetchStore(FirebaseFirestore.instance);
 
   @override
     Widget build(BuildContext context) {
-      return FutureBuilder<List<Store>>(
-        future: future,
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: CircularProgressIndicator());
-          } else if (snapshot.hasError) {
-            return Center(child: Text('Error: ${snapshot.error}'));
-          } else if (!snapshot.hasData) {
-            return const Center(child: Text('No data found'));
-          }
+      return Scaffold(
+        appBar: AppBar(
+          title: const Text('店舗ページ'),
+        ),
+        body: FutureBuilder<List<Store>>(
+            future: future,
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(child: CircularProgressIndicator());
+              } else if (snapshot.hasError) {
+                return Center(child: Text('Error: ${snapshot.error}'));
+              } else if (!snapshot.hasData) {
+                return const Center(child: Text('No data found'));
+              }
 
-          List<Store> stores = snapshot.data!;
-          return FlutterMap(
-            options: MapOptions(
-              initialCenter: stores[0].location,
-              initialZoom: 15.0,
-            ),
-            children: [
-              // Map Tile
-              TileLayer(
-                urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',          userAgentPackageName: 'com.latin_one.app',
-                maxNativeZoom: 19,
-              ),
+              List<Store> stores = snapshot.data!;
+              return FlutterMap(
+                options: MapOptions(
+                  initialCenter: stores[0].location,
+                  initialZoom: 15.0,
+                ),
+                children: [
+                  // Map Tile
+                  TileLayer(
+                    urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',          userAgentPackageName: 'com.latin_one.app',
+                    maxNativeZoom: 19,
+                  ),
 
-              // Store location
-              MarkerLayer(markers: createMarkers(context, stores)),
+                  // Store location
+                  MarkerLayer(markers: createMarkers(context, stores)),
 
-              // Attribution
-              const RichAttributionWidget(
-                attributions: [
-                  TextSourceAttribution(
-                    'OpenStreetMap contributors',
+                  // Attribution
+                  const RichAttributionWidget(
+                    attributions: [
+                      TextSourceAttribution(
+                        'OpenStreetMap contributors',
+                      ),
+                    ],
                   ),
                 ],
-              ),
-            ],
-          );
-        }
-      );
+              );
+            }
+        ),
+    );
+
     }
 
   List<Marker> createMarkers(BuildContext ctx, List<Store> stores) {
@@ -118,7 +124,8 @@ class StorePage extends StatelessWidget {
                 onPressed: () => {
                   orderData.changeStore(store),
                   Navigator.pop(context),
-                  GoRouter.of(context).go('/order'),
+                  // GoRouter.of(context).go('/order'),
+                  context.pop(),
                 },
                 child: const Text('この店舗を選択'),
               ),

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -6,6 +6,7 @@ import 'pages/store_page.dart';
 import 'pages/product_page.dart';
 import 'pages/account_page.dart';
 import 'pages/layout.dart';
+import 'pages/cart_page.dart';
 
 final GlobalKey<NavigatorState> _rootNavigatorKey =
     GlobalKey<NavigatorState>(debugLabel: 'root');
@@ -60,10 +61,17 @@ final GoRouter router = GoRouter(
           routes: <RouteBase>[
             GoRoute(
               path: '/product',
-              builder: (BuildContext context, GoRouterState state) {
-                final isSelectable = state.extra as bool;
-                return ProductPage(isSelectable: isSelectable);
-              }
+              builder: (BuildContext context, GoRouterState state) =>
+                const ProductPage()
+            ),
+          ],
+        ),
+        StatefulShellBranch(
+          routes: <RouteBase>[
+            GoRoute(
+              path: '/cart',
+              builder: (BuildContext context, GoRouterState state) =>
+                const CartPage(),
             ),
           ],
         ),


### PR DESCRIPTION
すーぱーこみっとまつり
+ 商品選択から購入までのページ遷移を一方通行にした．
 + ホームページとオーダーページの中間に，選択した商品だけを表示(増減と削除可)する，カートページを追加した．
+ Bottom Navigation bar を削除した．